### PR TITLE
Fixed slow bootstrap.

### DIFF
--- a/src/hardware/cpu.rs
+++ b/src/hardware/cpu.rs
@@ -126,10 +126,7 @@ impl CPU {
             let mut opcode = self.fetch_byte_immediate();
             if opcode == 0xCB {bitwise = true; opcode = self.fetch_byte_immediate();}
 
-            debugger.stop_if_needed(old_pc, self, &instr_set);
-
-            if self.pc.r() >= 0x0100 {self.bus.in_bios = false;}
-                    
+            debugger.stop_if_needed(old_pc, self, &instr_set);              
              
             if !instr_set.is_implemented(opcode, bitwise) {
                 println!("Unimplemented instruction {}0x{:0X}\nProcessor state:\n{}", 
@@ -175,7 +172,6 @@ impl CPU {
     }
 
     pub fn write_byte(&mut self, addr: u16, val: u8) {
-        if addr == 0xFF50 { println!("BIOS Disabled!"); return;}
         self.bus.write_byte(addr, val)
     }
 

--- a/src/hardware/instructions.rs
+++ b/src/hardware/instructions.rs
@@ -364,7 +364,7 @@ fn create_isa <'i>() -> Vec<Instruction<'i>> {
         [0x1B, inst!("DEC DE", |cpu, op|{dec_16!("DE", cpu); 2})], 
         [0x1C, inst!("INC E", |cpu, op| {inc!(cpu.regs.e, cpu, false); 1})], 
         [0x1D, inst!("DEC E", |cpu, op|{dec!(cpu.regs.e, cpu, false); 1})],      
-        [0x1E, inst!("LD E,n", |cpu, op|{load_byte_imm_u8!(cpu.regs.h, cpu); 2})],
+        [0x1E, inst!("LD E,n", |cpu, op|{load_byte_imm_u8!(cpu.regs.e, cpu); 2})],
 
         [0x20, inst!("JR NZ,n", |cpu, op|{if jump_cond_imm(cpu, JumpImmCond::NZ){3} else {2}})],
         [0x21, inst!("LD HL,nn", |cpu, op|{load_word_imm_u8!(cpu.regs.h, cpu.regs.l, cpu); 3})],   

--- a/src/hardware/memory/bus.rs
+++ b/src/hardware/memory/bus.rs
@@ -27,8 +27,6 @@ pub struct BUS {
     storage_ram: PLAIN_RAM,
     storage_zero_ram: PLAIN_RAM,
     io_registers: IORegs,     
-
-    pub in_bios: bool
 }
 
 impl BUS {
@@ -40,8 +38,6 @@ impl BUS {
             storage_ram: PLAIN_RAM::new(INTERNAL_RAM_START, INTERNAL_RAM_END),
             storage_zero_ram: PLAIN_RAM::new(ZERO_PAGE_RAM_START, ZERO_PAGE_RAM_END),
             io_registers: IORegs::new(),
-
-            in_bios: true
         }
     }
 
@@ -50,7 +46,7 @@ impl BUS {
     }
 
     pub fn read_byte(&self, addr: u16) -> u8 {
-        if self.in_bios && self.boot_rom.in_region(addr) {
+        if self.io_registers.boot_rom_enabled() && self.boot_rom.in_region(addr) {
             return self.boot_rom.read_byte(addr);
         } else if self.cartridge.in_region(addr) {
             return self.cartridge.read_byte(addr)


### PR DESCRIPTION
That hellishly slow boot strap was caused by the E register not being set as the instruction was incorrect. Resulting in the value staying at 0xE0 instead of being set to 2, in turn running the VBLANK loop over 200 times too many.

I have also added the bootstrap enable register (FF50) that is written to at the end of the bootstrap.